### PR TITLE
cacheApi

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,7 @@ import ScrollToTop from "./components/ScrollToTop";
 import { connect } from "react-redux";
 
 function App(props) {
+  api.book.get();
   const { books } = props;
   const routes = [
     { path: "/category/:name", as: Category },

--- a/src/components/FrontPage.js
+++ b/src/components/FrontPage.js
@@ -8,7 +8,7 @@ import { connect } from "react-redux";
 import HomepageIntro from "./Intro";
 
 const frontPage = (props) => {
-  isEmpty(props.categories) && api.category.read();
+  api.category.read();
   const background = {
     backgroundImage: `url(${frontpgImg})`,
   };

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -4,7 +4,7 @@ import { connect } from "react-redux";
 import { api } from "../store";
 
 function searchBar({ books, className }) {
-  isEmpty(books) && api.book.read();
+  api.book.read();
   return (
     <div className={"ma2 tc " + className}>
       <input

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -47,10 +47,9 @@ const requestFactory = (
        method: ${method}`;
   }
 
-  const cacheKey = [resourceName, method].join(".");
-  if (!requestOptions.force && methods[method] === "get" && cache[cacheKey])
-    return;
   const url = [baseURL, resourceName, id || ""].join("/") + "?" + urlQuery;
+  if (!requestOptions.force && methods[method] === "get" && cache[url]) return;
+
   let options = {
     method,
     headers: {
@@ -65,7 +64,7 @@ const requestFactory = (
     payload: (await fetch(url, options)).json(),
   };
   return dispatch(requestAction).then(({ value }) => {
-    cache[cacheKey] = true;
+    cache[url] = true;
     isArray(value) && (value = keyBy(value, "id"));
     const key = camelCase("update_" + resourceName);
     return dispatch(actions[key](value));


### PR DESCRIPTION
just simplifying the interface for the API. It doesn't cover all cases,
but it covers the ones that we have right now.

- simple api caching for get requests === better developer interface
